### PR TITLE
fix: Use new question when calling QA chain

### DIFF
--- a/langchain/src/chains/chat_vector_db_chain.ts
+++ b/langchain/src/chains/chat_vector_db_chain.ts
@@ -121,7 +121,7 @@ export class ChatVectorDBQAChain
     }
     const docs = await this.vectorstore.similaritySearch(newQuestion, this.k);
     const inputs = {
-      question,
+      question: newQuestion,
       input_documents: docs,
       chat_history: chatHistory,
     };


### PR DESCRIPTION
Hi! I had some struggles in achieving a chat-like experience using the `ChatVectorDBQAChain`. After some digging I found that the generated question based on chat history is not used in the following `QAChain` call. Is this intentional?